### PR TITLE
reverse issue fixed for Farsi words

### DIFF
--- a/main/static/css/style.css
+++ b/main/static/css/style.css
@@ -42,6 +42,7 @@ body {
     white-space: pre-wrap;
     word-wrap: break-word;
     text-align: justify;
+    unicode-bidi: embed;
 }
 
 .code-snippet-lang {


### PR DESCRIPTION
As explained here (https://www.w3schools.com/cssref/pr_text_unicode-bidi.asp), using this style will allow you to keep the order of a word chars when it has a different direction.

This fix if for my issue (#45).
Thank you Ali.